### PR TITLE
fix: product info not showing correctly

### DIFF
--- a/artemis-plugin/src/artemis-plugin/index.ts
+++ b/artemis-plugin/src/artemis-plugin/index.ts
@@ -41,13 +41,13 @@ configManager.configure(config => {
     ],
   }
   config.about = {
-    title: 'ActiveMQ Artemis Management Console',
-    description: '',
-    productInfo: [
-      { name: 'Artemis', value: '1.0.1' },
-    ],
-    copyright: '',
-    imgSrc: '/artemis-plugin/branding/activemq.png',
+    ...config.about,
+    ...{
+      title: 'ActiveMQ Artemis Management Console',
+      description: '',
+      copyright: '',
+      imgSrc: '/artemis-plugin/branding/activemq.png',
+    }
   }
   // If you want to disable specific plugins, you can specify the paths to disable them.
   //config.disabledRoutes = ['/simple-plugin']


### PR DESCRIPTION
@andytaylor The About page didn't display product info correctly. This fix not only lists Artemis plugin version but also Hawtio and Hawtio React versions.